### PR TITLE
Make RuboCop lints pass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,13 +19,25 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Metrics/LineLength:
+  Enabled: false
+
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
 Naming/AccessorMethodName:
   Enabled: false
 
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 Style/AsciiComments:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 AllCops:

--- a/examples/customers.rb
+++ b/examples/customers.rb
@@ -2,24 +2,24 @@ require 'square'
 
 # Initialize Square Client
 square = Square::Client.new(
-  access_token: 'ACCESS_TOKEN',
+  access_token: 'ACCESS_TOKEN'
 )
 
 customers_api = square.customers
 
 # Create Customer
 customer = {
-      "given_name": "John",
-      "family_name": "Smith",
-      "address": {
-          "address_line_1": "500 Electric Ave",
-          "address_line_2": "Suite 600",
-          "locality": "New York",
-          "administrative_district_level_1": "NY",
-          "postal_code": "98100",
-          "country": "US"
-      }
+  "given_name": "John",
+  "family_name": "Smith",
+  "address": {
+    "address_line_1": "500 Electric Ave",
+    "address_line_2": "Suite 600",
+    "locality": "New York",
+    "administrative_district_level_1": "NY",
+    "postal_code": "98100",
+    "country": "US"
   }
+}
 
 result = customers_api.create_customer(body: customer)
 if result.success?
@@ -40,7 +40,7 @@ result = customers_api.list_customers
 puts "list_customers:\n #{result.data.customers.count} customer(s)\n\n"
 
 # Update Customer
-result = customers_api.update_customer(customer_id: created_customer_id, body: {"family_name": "Jackson"})
+result = customers_api.update_customer(customer_id: created_customer_id, body: { "family_name": "Jackson" })
 puts "update_customer:\n #{result.data}\n\n"
 
 # Delete Customer

--- a/lib/square/api/base_api.rb
+++ b/lib/square/api/base_api.rb
@@ -20,27 +20,24 @@ module Square
 
     def validate_parameters(args)
       args.each do |_name, value|
-        if value.nil?
-          raise ArgumentError, "Required parameter #{_name} cannot be nil."
-        end
+        raise ArgumentError, "Required parameter #{_name} cannot be nil." if value.nil?
       end
     end
 
     def execute_request(request, binary: false)
-      @http_call_back.on_before_request(request) if @http_call_back
+      @http_call_back&.on_before_request(request)
 
       APIHelper.clean_hash(request.headers)
       request.headers.merge!(@global_headers)
-      unless config.additional_headers.nil?
-        request.headers.merge!(config.additional_headers)
-      end
+      request.headers.merge!(config.additional_headers) unless config.additional_headers.nil?
 
       response = if binary
                    config.http_client.execute_as_binary(request)
                  else
                    config.http_client.execute_as_string(request)
                  end
-      @http_call_back.on_after_response(response) if @http_call_back
+
+      @http_call_back&.on_after_response(response)
 
       response
     end

--- a/lib/square/api_helper.rb
+++ b/lib/square/api_helper.rb
@@ -137,7 +137,7 @@ module Square
     # Parses JSON string.
     # @param [String] A JSON string.
     def self.json_deserialize(json)
-      return JSON.parse(json, symbolize_names: true)
+      JSON.parse(json, symbolize_names: true)
     rescue StandardError
       raise TypeError, 'Server responded with invalid JSON.'
     end
@@ -166,6 +166,7 @@ module Square
       a.each do |key, value_a|
         b.each do |k, value_b|
           next unless key == k
+
           x[k] = []
           if value_a.instance_of? Array
             value_a.each do |v|

--- a/lib/square/http/api_response.rb
+++ b/lib/square/http/api_response.rb
@@ -30,7 +30,7 @@ module Square
           end.new(*data.values)
 
           @cursor = data.fetch(:cursor, nil)
-          data.reject! { |k| k == :cursor || k == :errors }
+          data.reject! { |k| %i[cursor errors].include?(k) }
           @data = Struct.new(*data.keys).new(*data.values) if data.keys.any?
         end
       else

--- a/lib/square/http/faraday_client.rb
+++ b/lib/square/http/faraday_client.rb
@@ -23,7 +23,7 @@ module Square
                                 backoff_factor: backoff_factor
         faraday.adapter Faraday.default_adapter
         faraday.options[:params_encoder] = Faraday::FlatParamsEncoder
-        faraday.options[:timeout] = timeout if timeout > 0
+        faraday.options[:timeout] = timeout if timeout.positive?
       end
     end
 
@@ -34,9 +34,7 @@ module Square
         http_request.query_url
       ) do |request|
         request.headers = http_request.headers
-        unless http_request.parameters.empty?
-          request.body = http_request.parameters
-        end
+        request.body = http_request.parameters unless http_request.parameters.empty?
       end
       convert_response(response, http_request)
     end
@@ -48,9 +46,7 @@ module Square
         http_request.query_url
       ) do |request|
         request.headers = http_request.headers
-        unless http_request.parameters.empty?
-          request.body = http_request.parameters
-        end
+        request.body = http_request.parameters unless http_request.parameters.empty?
       end
       convert_response(response, http_request)
     end

--- a/spec/user_journey_spec.rb
+++ b/spec/user_journey_spec.rb
@@ -14,18 +14,18 @@ describe "UserJourney" do
 
   let :customer do
     {
-        "given_name": "Amelia",
-        "family_name": "Earhart",
-        "phone_number": phone_number,
-        "note": "a customer",
-        "address": {
-            "address_line_1": "500 Electric Ave",
-            "address_line_2": "Suite 600",
-            "locality": "New York",
-            "administrative_district_level_1": "NY",
-            "postal_code": postal_code,
-            "country": "US"
-        }
+      "given_name": "Amelia",
+      "family_name": "Earhart",
+      "phone_number": phone_number,
+      "note": "a customer",
+      "address": {
+        "address_line_1": "500 Electric Ave",
+        "address_line_2": "Suite 600",
+        "locality": "New York",
+        "administrative_district_level_1": "NY",
+        "postal_code": postal_code,
+        "country": "US"
+      }
     }
   end
 
@@ -70,7 +70,6 @@ describe "UserJourney" do
     end
   end
 
-
   # There is no sandbox support for V1 endpoints as production token is required for the following tests
   # describe 'V1 Category' do
   #   it 'should succeed for each endpoint call' do
@@ -110,7 +109,6 @@ describe "UserJourney" do
       # create
       response = sq.customers.create_customer(body: customer)
       assert_equal response.data.customer[:phone_number], phone_number
-
 
       assert_equal response.status_code, 200
       created_customer = response.data.customer


### PR DESCRIPTION
This disables RuboCop lints for `Metrics/LineLength`, `Naming/UncommunicativeMethodParamName`, `Style/StringLiterals`, and `Style/FrozenStringLiteralComment` and then fixes remaining failing lints.

Closes #15.