### PR TITLE
Require `faraday` > 1.0, Ruby > 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
 - 2.4.6
 - 2.5.5
 - 2.6.3
+- 2.7.1
 - truffleruby
 env:
   global:

--- a/lib/square/api/catalog_api.rb
+++ b/lib/square/api/catalog_api.rb
@@ -253,8 +253,10 @@ module Square
       _query_builder << '/v2/catalog/list'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'types' => types
+        {
+          'cursor' => cursor,
+          'types' => types
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/customers_api.rb
+++ b/lib/square/api/customers_api.rb
@@ -31,9 +31,11 @@ module Square
       _query_builder << '/v2/customers'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'sort_field' => sort_field,
-        'sort_order' => sort_order
+        {
+          'cursor' => cursor,
+          'sort_field' => sort_field,
+          'sort_order' => sort_order
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/employees_api.rb
+++ b/lib/square/api/employees_api.rb
@@ -24,10 +24,12 @@ module Square
       _query_builder << '/v2/employees'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'status' => status,
-        'limit' => limit,
-        'cursor' => cursor
+        {
+          'location_id' => location_id,
+          'status' => status,
+          'limit' => limit,
+          'cursor' => cursor
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/labor_api.rb
+++ b/lib/square/api/labor_api.rb
@@ -22,9 +22,11 @@ module Square
       _query_builder << '/v2/labor/break-types'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'limit' => limit,
-        'cursor' => cursor
+        {
+          'location_id' => location_id,
+          'limit' => limit,
+          'cursor' => cursor
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -214,9 +216,11 @@ module Square
       _query_builder << '/v2/labor/employee-wages'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'employee_id' => employee_id,
-        'limit' => limit,
-        'cursor' => cursor
+        {
+          'employee_id' => employee_id,
+          'limit' => limit,
+          'cursor' => cursor
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -487,8 +491,10 @@ module Square
       _query_builder << '/v2/labor/workweek-configs'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'limit' => limit,
-        'cursor' => cursor
+        {
+          'limit' => limit,
+          'cursor' => cursor
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/merchants_api.rb
+++ b/lib/square/api/merchants_api.rb
@@ -23,7 +23,9 @@ module Square
       _query_builder << '/v2/merchants'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor
+        {
+          'cursor' => cursor
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/payments_api.rb
+++ b/lib/square/api/payments_api.rb
@@ -44,14 +44,16 @@ module Square
       _query_builder << '/v2/payments'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'begin_time' => begin_time,
-        'end_time' => end_time,
-        'sort_order' => sort_order,
-        'cursor' => cursor,
-        'location_id' => location_id,
-        'total' => total,
-        'last_4' => last_4,
-        'card_brand' => card_brand
+        {
+          'begin_time' => begin_time,
+          'end_time' => end_time,
+          'sort_order' => sort_order,
+          'cursor' => cursor,
+          'location_id' => location_id,
+          'total' => total,
+          'last_4' => last_4,
+          'card_brand' => card_brand
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -127,7 +129,7 @@ module Square
     # In this case, you can
     # direct Square to cancel the payment using this endpoint. In the request,
     # you provide the same
-    # idempotency key that you provided in your CreatePayment request you want 
+    # idempotency key that you provided in your CreatePayment request you want
     # to cancel. After
     # cancelling the payment, you can submit your CreatePayment request again.
     # Note that if no payment with the specified idempotency key is found, no

--- a/lib/square/api/refunds_api.rb
+++ b/lib/square/api/refunds_api.rb
@@ -45,13 +45,15 @@ module Square
       _query_builder << '/v2/refunds'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'begin_time' => begin_time,
-        'end_time' => end_time,
-        'sort_order' => sort_order,
-        'cursor' => cursor,
-        'location_id' => location_id,
-        'status' => status,
-        'source_type' => source_type
+        {
+          'begin_time' => begin_time,
+          'end_time' => end_time,
+          'sort_order' => sort_order,
+          'cursor' => cursor,
+          'location_id' => location_id,
+          'status' => status,
+          'source_type' => source_type
+        }
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api_helper.rb
+++ b/lib/square/api_helper.rb
@@ -209,23 +209,23 @@ module Square
           obj.each do |value|
             abc = if formatting == 'unindexed'
                     APIHelper.form_encode(value, instance_name + '[]',
-                                          formatting: formatting)
+                                          {formatting: formatting})
                   else
                     APIHelper.form_encode(value, instance_name,
-                                          formatting: formatting)
+                                          {formatting: formatting})
                   end
             retval = APIHelper.custom_merge(retval, abc)
           end
         else
           obj.each_with_index do |value, index|
             retval.merge!(APIHelper.form_encode(value, instance_name + '[' +
-              index.to_s + ']', formatting: formatting))
+              index.to_s + ']', {formatting: formatting}))
           end
         end
       elsif obj.instance_of? Hash
         obj.each do |key, value|
           retval.merge!(APIHelper.form_encode(value, instance_name + '[' +
-            key.to_s + ']', formatting: formatting))
+            key.to_s + ']', {formatting: formatting}))
         end
       elsif obj.instance_of? File
         retval[instance_name] = UploadIO.new(

--- a/square.gemspec
+++ b/square.gemspec
@@ -8,13 +8,13 @@ Gem::Specification.new do |s|
   s.homepage = 'https://squareup.com/developers'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.2')
-  s.add_dependency('faraday', '~> 0.15')
-  s.add_dependency('faraday_middleware', '~> 0.13')
+  s.add_dependency('faraday', '~> 1.0')
+  s.add_dependency('faraday_middleware', '~> 1.0')
   s.add_dependency('certifi', '~> 2018.1')
   s.add_dependency('faraday-http-cache', '~> 2.0')
   s.add_development_dependency('minitest', '~> 5.0')
   s.add_development_dependency('minitest-proveit', '~> 1.0')
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '~> 2.3'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Currently Farday 1.0 requires 2.3.0, so these requirements are
functionally equivalent.