### PR TITLE
faraday dependency removed from square gem refs #16364

### DIFF
--- a/square.gemspec
+++ b/square.gemspec
@@ -8,8 +8,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://squareup.com/developers'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.2')
-  s.add_dependency('faraday', '~> 0.15')
-  s.add_dependency('faraday_middleware', '~> 0.13')
   s.add_dependency('certifi', '~> 2018.1')
   s.add_dependency('faraday-http-cache', '~> 2.0')
   s.add_development_dependency('minitest', '~> 5.0')


### PR DESCRIPTION
https://pm.7vals.com/issues/16364

Cycle 0

- [x] Correct base branch