### PR TITLE
Separate keyword arguments into parameters hash

### DIFF
--- a/lib/square/api/bank_accounts_api.rb
+++ b/lib/square/api/bank_accounts_api.rb
@@ -23,14 +23,19 @@ module Square
     def list_bank_accounts(cursor: nil,
                            limit: nil,
                            location_id: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor,
+        'limit' => limit,
+        'location_id' => location_id
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bank-accounts'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'limit' => limit,
-        'location_id' => location_id
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -64,12 +69,17 @@ module Square
     # -account-by-using-an-id-issued-by-v1-bank-accounts-api).
     # @return [GetBankAccountByV1IdResponse Hash] response from the API call
     def get_bank_account_by_v1_id(v1_bank_account_id:)
+      # Prepare parameters.
+      _parameters = {
+        'v1_bank_account_id' => { 'value' => v1_bank_account_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bank-accounts/by-v1-id/{v1_bank_account_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'v1_bank_account_id' => { 'value' => v1_bank_account_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -100,12 +110,17 @@ module Square
     # the desired `BankAccount`.
     # @return [GetBankAccountResponse Hash] response from the API call
     def get_bank_account(bank_account_id:)
+      # Prepare parameters.
+      _parameters = {
+        'bank_account_id' => { 'value' => bank_account_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bank-accounts/{bank_account_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'bank_account_id' => { 'value' => bank_account_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/bookings_api.rb
+++ b/lib/square/api/bookings_api.rb
@@ -118,15 +118,20 @@ module Square
                                           limit: nil,
                                           cursor: nil,
                                           location_id: nil)
+      # Prepare parameters.
+      _parameters = {
+        'bookable_only' => bookable_only,
+        'limit' => limit,
+        'cursor' => cursor,
+        'location_id' => location_id
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bookings/team-member-booking-profiles'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'bookable_only' => bookable_only,
-        'limit' => limit,
-        'cursor' => cursor,
-        'location_id' => location_id
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -156,12 +161,17 @@ module Square
     # member to retrieve.
     # @return [RetrieveTeamMemberBookingProfileResponse Hash] response from the API call
     def retrieve_team_member_booking_profile(team_member_id:)
+      # Prepare parameters.
+      _parameters = {
+        'team_member_id' => { 'value' => team_member_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bookings/team-member-booking-profiles/{team_member_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'team_member_id' => { 'value' => team_member_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -192,12 +202,17 @@ module Square
     # booking.
     # @return [RetrieveBookingResponse Hash] response from the API call
     def retrieve_booking(booking_id:)
+      # Prepare parameters.
+      _parameters = {
+        'booking_id' => { 'value' => booking_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bookings/{booking_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'booking_id' => { 'value' => booking_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -231,12 +246,17 @@ module Square
     # @return [UpdateBookingResponse Hash] response from the API call
     def update_booking(booking_id:,
                        body:)
+      # Prepare parameters.
+      _parameters = {
+        'booking_id' => { 'value' => booking_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bookings/{booking_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'booking_id' => { 'value' => booking_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -273,12 +293,17 @@ module Square
     # @return [CancelBookingResponse Hash] response from the API call
     def cancel_booking(booking_id:,
                        body:)
+      # Prepare parameters.
+      _parameters = {
+        'booking_id' => { 'value' => booking_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/bookings/{booking_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'booking_id' => { 'value' => booking_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/cash_drawers_api.rb
+++ b/lib/square/api/cash_drawers_api.rb
@@ -27,17 +27,22 @@ module Square
                                 end_time: nil,
                                 limit: nil,
                                 cursor: nil)
-      # Prepare query url.
-      _query_builder = config.get_base_uri
-      _query_builder << '/v2/cash-drawers/shifts'
-      _query_builder = APIHelper.append_url_with_query_parameters(
-        _query_builder,
+      # Prepare parameters.
+      _parameters = {
         'location_id' => location_id,
         'sort_order' => sort_order,
         'begin_time' => begin_time,
         'end_time' => end_time,
         'limit' => limit,
         'cursor' => cursor
+      }
+
+      # Prepare query url.
+      _query_builder = config.get_base_uri
+      _query_builder << '/v2/cash-drawers/shifts'
+      _query_builder = APIHelper.append_url_with_query_parameters(
+        _query_builder,
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -71,16 +76,24 @@ module Square
     # @return [RetrieveCashDrawerShiftResponse Hash] response from the API call
     def retrieve_cash_drawer_shift(location_id:,
                                    shift_id:)
+      # Prepare parameters.
+      _template_parameters = {
+        'shift_id' => { 'value' => shift_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'location_id' => location_id
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/cash-drawers/shifts/{shift_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'shift_id' => { 'value' => shift_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -118,18 +131,26 @@ module Square
                                       shift_id:,
                                       limit: nil,
                                       cursor: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'shift_id' => { 'value' => shift_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'location_id' => location_id,
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/cash-drawers/shifts/{shift_id}/events'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'shift_id' => { 'value' => shift_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'limit' => limit,
-        'cursor' => cursor
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/catalog_api.rb
+++ b/lib/square/api/catalog_api.rb
@@ -260,14 +260,19 @@ module Square
     def list_catalog(cursor: nil,
                      types: nil,
                      catalog_version: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor,
+        'types' => types,
+        'catalog_version' => catalog_version
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/catalog/list'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'types' => types,
-        'catalog_version' => catalog_version
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -340,12 +345,17 @@ module Square
     # catalog item will delete its catalog item variations).
     # @return [DeleteCatalogObjectResponse Hash] response from the API call
     def delete_catalog_object(object_id:)
+      # Prepare parameters.
+      _parameters = {
+        'object_id' => { 'value' => object_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/catalog/object/{object_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'object_id' => { 'value' => object_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -398,17 +408,25 @@ module Square
     def retrieve_catalog_object(object_id:,
                                 include_related_objects: false,
                                 catalog_version: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'object_id' => { 'value' => object_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'include_related_objects' => include_related_objects,
+        'catalog_version' => catalog_version
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/catalog/object/{object_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'object_id' => { 'value' => object_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'include_related_objects' => include_related_objects,
-        'catalog_version' => catalog_version
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/checkout_api.rb
+++ b/lib/square/api/checkout_api.rb
@@ -16,12 +16,17 @@ module Square
     # @return [CreateCheckoutResponse Hash] response from the API call
     def create_checkout(location_id:,
                         body:)
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/checkouts'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/customer_groups_api.rb
+++ b/lib/square/api/customer_groups_api.rb
@@ -13,12 +13,17 @@ module Square
     # for more information.
     # @return [ListCustomerGroupsResponse Hash] response from the API call
     def list_customer_groups(cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/groups'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -83,12 +88,17 @@ module Square
     # to delete.
     # @return [DeleteCustomerGroupResponse Hash] response from the API call
     def delete_customer_group(group_id:)
+      # Prepare parameters.
+      _parameters = {
+        'group_id' => { 'value' => group_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/groups/{group_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'group_id' => { 'value' => group_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -118,12 +128,17 @@ module Square
     # to retrieve.
     # @return [RetrieveCustomerGroupResponse Hash] response from the API call
     def retrieve_customer_group(group_id:)
+      # Prepare parameters.
+      _parameters = {
+        'group_id' => { 'value' => group_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/groups/{group_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'group_id' => { 'value' => group_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -157,12 +172,17 @@ module Square
     # @return [UpdateCustomerGroupResponse Hash] response from the API call
     def update_customer_group(group_id:,
                               body:)
+      # Prepare parameters.
+      _parameters = {
+        'group_id' => { 'value' => group_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/groups/{group_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'group_id' => { 'value' => group_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/customer_segments_api.rb
+++ b/lib/square/api/customer_segments_api.rb
@@ -13,12 +13,17 @@ module Square
     # for more information.
     # @return [ListCustomerSegmentsResponse Hash] response from the API call
     def list_customer_segments(cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/segments'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -49,12 +54,17 @@ module Square
     # customer segment.
     # @return [RetrieveCustomerSegmentResponse Hash] response from the API call
     def retrieve_customer_segment(segment_id:)
+      # Prepare parameters.
+      _parameters = {
+        'segment_id' => { 'value' => segment_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/segments/{segment_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'segment_id' => { 'value' => segment_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/customers_api.rb
+++ b/lib/square/api/customers_api.rb
@@ -26,14 +26,19 @@ module Square
     def list_customers(cursor: nil,
                        sort_field: nil,
                        sort_order: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor,
+        'sort_field' => sort_field,
+        'sort_order' => sort_order
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'sort_field' => sort_field,
-        'sort_order' => sort_order
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -154,12 +159,17 @@ module Square
     # delete.
     # @return [DeleteCustomerResponse Hash] response from the API call
     def delete_customer(customer_id:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -189,12 +199,17 @@ module Square
     # retrieve.
     # @return [RetrieveCustomerResponse Hash] response from the API call
     def retrieve_customer(customer_id:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -237,12 +252,17 @@ module Square
     # @return [UpdateCustomerResponse Hash] response from the API call
     def update_customer(customer_id:,
                         body:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -282,12 +302,17 @@ module Square
     # @return [CreateCustomerCardResponse Hash] response from the API call
     def create_customer_card(customer_id:,
                              body:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}/cards'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -322,13 +347,18 @@ module Square
     # @return [DeleteCustomerCardResponse Hash] response from the API call
     def delete_customer_card(customer_id:,
                              card_id:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true },
+        'card_id' => { 'value' => card_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}/cards/{card_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true },
-        'card_id' => { 'value' => card_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -363,13 +393,18 @@ module Square
     # @return [RemoveGroupFromCustomerResponse Hash] response from the API call
     def remove_group_from_customer(customer_id:,
                                    group_id:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true },
+        'group_id' => { 'value' => group_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}/groups/{group_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true },
-        'group_id' => { 'value' => group_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -404,13 +439,18 @@ module Square
     # @return [AddGroupToCustomerResponse Hash] response from the API call
     def add_group_to_customer(customer_id:,
                               group_id:)
+      # Prepare parameters.
+      _parameters = {
+        'customer_id' => { 'value' => customer_id, 'encode' => true },
+        'group_id' => { 'value' => group_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/customers/{customer_id}/groups/{group_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'customer_id' => { 'value' => customer_id, 'encode' => true },
-        'group_id' => { 'value' => group_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/devices_api.rb
+++ b/lib/square/api/devices_api.rb
@@ -24,15 +24,20 @@ module Square
                           location_id: nil,
                           product_type: nil,
                           status: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor,
+        'location_id' => location_id,
+        'product_type' => product_type,
+        'status' => status
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/devices/codes'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'location_id' => location_id,
-        'product_type' => product_type,
-        'status' => status
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -98,12 +103,17 @@ module Square
     # device code.
     # @return [GetDeviceCodeResponse Hash] response from the API call
     def get_device_code(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/devices/codes/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/disputes_api.rb
+++ b/lib/square/api/disputes_api.rb
@@ -22,14 +22,19 @@ module Square
     def list_disputes(cursor: nil,
                       states: nil,
                       location_id: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor,
+        'states' => states,
+        'location_id' => location_id
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'states' => states,
-        'location_id' => location_id
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -59,12 +64,17 @@ module Square
     # want more details about.
     # @return [RetrieveDisputeResponse Hash] response from the API call
     def retrieve_dispute(dispute_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -99,12 +109,17 @@ module Square
     # want to accept.
     # @return [AcceptDisputeResponse Hash] response from the API call
     def accept_dispute(dispute_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/accept'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -133,12 +148,17 @@ module Square
     # @param [String] dispute_id Required parameter: The ID of the dispute.
     # @return [ListDisputeEvidenceResponse Hash] response from the API call
     def list_dispute_evidence(dispute_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/evidence'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -176,13 +196,18 @@ module Square
     # @return [RemoveDisputeEvidenceResponse Hash] response from the API call
     def remove_dispute_evidence(dispute_id:,
                                 evidence_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true },
+        'evidence_id' => { 'value' => evidence_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/evidence/{evidence_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true },
-        'evidence_id' => { 'value' => evidence_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -218,13 +243,18 @@ module Square
     # @return [RetrieveDisputeEvidenceResponse Hash] response from the API call
     def retrieve_dispute_evidence(dispute_id:,
                                   evidence_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true },
+        'evidence_id' => { 'value' => evidence_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/evidence/{evidence_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true },
-        'evidence_id' => { 'value' => evidence_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -262,12 +292,17 @@ module Square
     def create_dispute_evidence_file(dispute_id:,
                                      request: nil,
                                      image_file: nil)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/evidence_file'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -323,12 +358,17 @@ module Square
     # @return [CreateDisputeEvidenceTextResponse Hash] response from the API call
     def create_dispute_evidence_text(dispute_id:,
                                      body:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/evidence_text'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -368,12 +408,17 @@ module Square
     # you want to submit evidence for.
     # @return [SubmitEvidenceResponse Hash] response from the API call
     def submit_evidence(dispute_id:)
+      # Prepare parameters.
+      _parameters = {
+        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/disputes/{dispute_id}/submit-evidence'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'dispute_id' => { 'value' => dispute_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/employees_api.rb
+++ b/lib/square/api/employees_api.rb
@@ -19,15 +19,20 @@ module Square
                        limit: nil,
                        cursor: nil)
       warn 'Endpoint list_employees in EmployeesApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => location_id,
+        'status' => status,
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/employees'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'status' => status,
-        'limit' => limit,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -58,12 +63,17 @@ module Square
     # @return [RetrieveEmployeeResponse Hash] response from the API call
     def retrieve_employee(id:)
       warn 'Endpoint retrieve_employee in EmployeesApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/employees/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/inventory_api.rb
+++ b/lib/square/api/inventory_api.rb
@@ -11,12 +11,17 @@ module Square
     # [InventoryAdjustment](#type-inventoryadjustment) to retrieve.
     # @return [RetrieveInventoryAdjustmentResponse Hash] response from the API call
     def retrieve_inventory_adjustment(adjustment_id:)
+      # Prepare parameters.
+      _parameters = {
+        'adjustment_id' => { 'value' => adjustment_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/inventory/adjustment/{adjustment_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'adjustment_id' => { 'value' => adjustment_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -166,12 +171,17 @@ module Square
     # [InventoryPhysicalCount](#type-inventoryphysicalcount) to retrieve.
     # @return [RetrieveInventoryPhysicalCountResponse Hash] response from the API call
     def retrieve_inventory_physical_count(physical_count_id:)
+      # Prepare parameters.
+      _parameters = {
+        'physical_count_id' => { 'value' => physical_count_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/inventory/physical-count/{physical_count_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'physical_count_id' => { 'value' => physical_count_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -214,17 +224,25 @@ module Square
     def retrieve_inventory_count(catalog_object_id:,
                                  location_ids: nil,
                                  cursor: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'catalog_object_id' => { 'value' => catalog_object_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'location_ids' => location_ids,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/inventory/{catalog_object_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'catalog_object_id' => { 'value' => catalog_object_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_ids' => location_ids,
-        'cursor' => cursor
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -272,17 +290,24 @@ module Square
     def retrieve_inventory_changes(catalog_object_id:,
                                    location_ids: nil,
                                    cursor: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'catalog_object_id' => { 'value' => catalog_object_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'location_ids' => location_ids,
+        'cursor' => cursor
+      }
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/inventory/{catalog_object_id}/changes'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'catalog_object_id' => { 'value' => catalog_object_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_ids' => location_ids,
-        'cursor' => cursor
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/invoices_api.rb
+++ b/lib/square/api/invoices_api.rb
@@ -22,14 +22,19 @@ module Square
     def list_invoices(location_id:,
                       cursor: nil,
                       limit: nil)
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => location_id,
+        'cursor' => cursor,
+        'limit' => limit
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'cursor' => cursor,
-        'limit' => limit
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -145,16 +150,24 @@ module Square
     # @return [DeleteInvoiceResponse Hash] response from the API call
     def delete_invoice(invoice_id:,
                        version: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'version' => version
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices/{invoice_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'version' => version
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -184,12 +197,17 @@ module Square
     # retrieve.
     # @return [GetInvoiceResponse Hash] response from the API call
     def get_invoice(invoice_id:)
+      # Prepare parameters.
+      _parameters = {
+        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices/{invoice_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -230,12 +248,17 @@ module Square
     # @return [UpdateInvoiceResponse Hash] response from the API call
     def update_invoice(invoice_id:,
                        body:)
+      # Prepare parameters.
+      _parameters = {
+        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices/{invoice_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -274,12 +297,17 @@ module Square
     # @return [CancelInvoiceResponse Hash] response from the API call
     def cancel_invoice(invoice_id:,
                        body:)
+      # Prepare parameters.
+      _parameters = {
+        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices/{invoice_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -327,12 +355,17 @@ module Square
     # @return [PublishInvoiceResponse Hash] response from the API call
     def publish_invoice(invoice_id:,
                         body:)
+      # Prepare parameters.
+      _parameters = {
+        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/invoices/{invoice_id}/publish'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'invoice_id' => { 'value' => invoice_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/labor_api.rb
+++ b/lib/square/api/labor_api.rb
@@ -17,14 +17,19 @@ module Square
     def list_break_types(location_id: nil,
                          limit: nil,
                          cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => location_id,
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/break-types'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'location_id' => location_id,
-        'limit' => limit,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -101,12 +106,17 @@ module Square
     # deleted.
     # @return [DeleteBreakTypeResponse Hash] response from the API call
     def delete_break_type(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/break-types/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -136,12 +146,17 @@ module Square
     # retrieved.
     # @return [GetBreakTypeResponse Hash] response from the API call
     def get_break_type(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/break-types/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -175,12 +190,17 @@ module Square
     # @return [UpdateBreakTypeResponse Hash] response from the API call
     def update_break_type(id:,
                           body:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/break-types/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -220,14 +240,19 @@ module Square
                             limit: nil,
                             cursor: nil)
       warn 'Endpoint list_employee_wages in LaborApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'employee_id' => employee_id,
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/employee-wages'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'employee_id' => employee_id,
-        'limit' => limit,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -258,12 +283,17 @@ module Square
     # @return [GetEmployeeWageResponse Hash] response from the API call
     def get_employee_wage(id:)
       warn 'Endpoint get_employee_wage in LaborApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/employee-wages/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -389,12 +419,17 @@ module Square
     # deleted.
     # @return [DeleteShiftResponse Hash] response from the API call
     def delete_shift(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/shifts/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -424,12 +459,17 @@ module Square
     # retrieved.
     # @return [GetShiftResponse Hash] response from the API call
     def get_shift(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/shifts/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -468,12 +508,17 @@ module Square
     # @return [UpdateShiftResponse Hash] response from the API call
     def update_shift(id:,
                      body:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/shifts/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -512,14 +557,19 @@ module Square
     def list_team_member_wages(team_member_id: nil,
                                limit: nil,
                                cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'team_member_id' => team_member_id,
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/team-member-wages'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'team_member_id' => team_member_id,
-        'limit' => limit,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -549,12 +599,17 @@ module Square
     # retrieved.
     # @return [GetTeamMemberWageResponse Hash] response from the API call
     def get_team_member_wage(id:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/team-member-wages/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -587,13 +642,18 @@ module Square
     # @return [ListWorkweekConfigsResponse Hash] response from the API call
     def list_workweek_configs(limit: nil,
                               cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'limit' => limit,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/workweek-configs'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'limit' => limit,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -627,12 +687,17 @@ module Square
     # @return [UpdateWorkweekConfigResponse Hash] response from the API call
     def update_workweek_config(id:,
                                body:)
+      # Prepare parameters.
+      _parameters = {
+        'id' => { 'value' => id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/labor/workweek-configs/{id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'id' => { 'value' => id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/locations_api.rb
+++ b/lib/square/api/locations_api.rb
@@ -80,12 +80,17 @@ module Square
     # main location.
     # @return [RetrieveLocationResponse Hash] response from the API call
     def retrieve_location(location_id:)
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -119,12 +124,17 @@ module Square
     # @return [UpdateLocationResponse Hash] response from the API call
     def update_location(location_id:,
                         body:)
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/loyalty_api.rb
+++ b/lib/square/api/loyalty_api.rb
@@ -82,12 +82,17 @@ module Square
     # account](#type-LoyaltyAccount) to retrieve.
     # @return [RetrieveLoyaltyAccountResponse Hash] response from the API call
     def retrieve_loyalty_account(account_id:)
+      # Prepare parameters.
+      _parameters = {
+        'account_id' => { 'value' => account_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/accounts/{account_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'account_id' => { 'value' => account_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -133,12 +138,17 @@ module Square
     # @return [AccumulateLoyaltyPointsResponse Hash] response from the API call
     def accumulate_loyalty_points(account_id:,
                                   body:)
+      # Prepare parameters.
+      _parameters = {
+        'account_id' => { 'value' => account_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/accounts/{account_id}/accumulate'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'account_id' => { 'value' => account_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -178,12 +188,17 @@ module Square
     # @return [AdjustLoyaltyPointsResponse Hash] response from the API call
     def adjust_loyalty_points(account_id:,
                               body:)
+      # Prepare parameters.
+      _parameters = {
+        'account_id' => { 'value' => account_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/accounts/{account_id}/adjust'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'account_id' => { 'value' => account_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -299,12 +314,17 @@ module Square
     # @return [CalculateLoyaltyPointsResponse Hash] response from the API call
     def calculate_loyalty_points(program_id:,
                                  body:)
+      # Prepare parameters.
+      _parameters = {
+        'program_id' => { 'value' => program_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/programs/{program_id}/calculate'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'program_id' => { 'value' => program_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -421,12 +441,17 @@ module Square
     # reward](#type-LoyaltyReward) to delete.
     # @return [DeleteLoyaltyRewardResponse Hash] response from the API call
     def delete_loyalty_reward(reward_id:)
+      # Prepare parameters.
+      _parameters = {
+        'reward_id' => { 'value' => reward_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/rewards/{reward_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'reward_id' => { 'value' => reward_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -456,12 +481,17 @@ module Square
     # reward](#type-LoyaltyReward) to retrieve.
     # @return [RetrieveLoyaltyRewardResponse Hash] response from the API call
     def retrieve_loyalty_reward(reward_id:)
+      # Prepare parameters.
+      _parameters = {
+        'reward_id' => { 'value' => reward_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/rewards/{reward_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'reward_id' => { 'value' => reward_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -502,12 +532,17 @@ module Square
     # @return [RedeemLoyaltyRewardResponse Hash] response from the API call
     def redeem_loyalty_reward(reward_id:,
                               body:)
+      # Prepare parameters.
+      _parameters = {
+        'reward_id' => { 'value' => reward_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/loyalty/rewards/{reward_id}/redeem'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'reward_id' => { 'value' => reward_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/merchants_api.rb
+++ b/lib/square/api/merchants_api.rb
@@ -18,12 +18,17 @@ module Square
     # previous response.
     # @return [ListMerchantsResponse Hash] response from the API call
     def list_merchants(cursor: nil)
+      # Prepare parameters.
+      _parameters = {
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/merchants'
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -54,12 +59,17 @@ module Square
     # merchant that is currently accessible to this call.
     # @return [RetrieveMerchantResponse Hash] response from the API call
     def retrieve_merchant(merchant_id:)
+      # Prepare parameters.
+      _parameters = {
+        'merchant_id' => { 'value' => merchant_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/merchants/{merchant_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'merchant_id' => { 'value' => merchant_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/o_auth_api.rb
+++ b/lib/square/api/o_auth_api.rb
@@ -39,12 +39,17 @@ module Square
                     body:,
                     authorization:)
       warn 'Endpoint renew_token in OAuthApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'client_id' => { 'value' => client_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/oauth2/clients/{client_id}/access-token/renew'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'client_id' => { 'value' => client_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/orders_api.rb
+++ b/lib/square/api/orders_api.rb
@@ -170,12 +170,17 @@ module Square
     # retrieve.
     # @return [RetrieveOrderResponse Hash] response from the API call
     def retrieve_order(order_id:)
+      # Prepare parameters.
+      _parameters = {
+        'order_id' => { 'value' => order_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/orders/{order_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'order_id' => { 'value' => order_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -225,12 +230,17 @@ module Square
     # @return [UpdateOrderResponse Hash] response from the API call
     def update_order(order_id:,
                      body:)
+      # Prepare parameters.
+      _parameters = {
+        'order_id' => { 'value' => order_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/orders/{order_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'order_id' => { 'value' => order_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -284,12 +294,17 @@ module Square
     # @return [PayOrderResponse Hash] response from the API call
     def pay_order(order_id:,
                   body:)
+      # Prepare parameters.
+      _parameters = {
+        'order_id' => { 'value' => order_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/orders/{order_id}/pay'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'order_id' => { 'value' => order_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/payments_api.rb
+++ b/lib/square/api/payments_api.rb
@@ -45,11 +45,8 @@ module Square
                       last_4: nil,
                       card_brand: nil,
                       limit: nil)
-      # Prepare query url.
-      _query_builder = config.get_base_uri
-      _query_builder << '/v2/payments'
-      _query_builder = APIHelper.append_url_with_query_parameters(
-        _query_builder,
+      # Prepare parameters.
+      _parameters = {
         'begin_time' => begin_time,
         'end_time' => end_time,
         'sort_order' => sort_order,
@@ -59,6 +56,14 @@ module Square
         'last_4' => last_4,
         'card_brand' => card_brand,
         'limit' => limit
+      }
+
+      # Prepare query url.
+      _query_builder = config.get_base_uri
+      _query_builder << '/v2/payments'
+      _query_builder = APIHelper.append_url_with_query_parameters(
+        _query_builder,
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -179,12 +184,17 @@ module Square
     # payment.
     # @return [GetPaymentResponse Hash] response from the API call
     def get_payment(payment_id:)
+      # Prepare parameters.
+      _parameters = {
+        'payment_id' => { 'value' => payment_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/payments/{payment_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'payment_id' => { 'value' => payment_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -216,12 +226,17 @@ module Square
     # identifying the payment to be canceled.
     # @return [CancelPaymentResponse Hash] response from the API call
     def cancel_payment(payment_id:)
+      # Prepare parameters.
+      _parameters = {
+        'payment_id' => { 'value' => payment_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/payments/{payment_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'payment_id' => { 'value' => payment_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -256,12 +271,17 @@ module Square
     # the payment to be completed.
     # @return [CompletePaymentResponse Hash] response from the API call
     def complete_payment(payment_id:)
+      # Prepare parameters.
+      _parameters = {
+        'payment_id' => { 'value' => payment_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/payments/{payment_id}/complete'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'payment_id' => { 'value' => payment_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/refunds_api.rb
+++ b/lib/square/api/refunds_api.rb
@@ -45,11 +45,8 @@ module Square
                              status: nil,
                              source_type: nil,
                              limit: nil)
-      # Prepare query url.
-      _query_builder = config.get_base_uri
-      _query_builder << '/v2/refunds'
-      _query_builder = APIHelper.append_url_with_query_parameters(
-        _query_builder,
+      # Prepare parameters.
+      _parameters = {
         'begin_time' => begin_time,
         'end_time' => end_time,
         'sort_order' => sort_order,
@@ -58,6 +55,14 @@ module Square
         'status' => status,
         'source_type' => source_type,
         'limit' => limit
+      }
+
+      # Prepare query url.
+      _query_builder = config.get_base_uri
+      _query_builder << '/v2/refunds'
+      _query_builder = APIHelper.append_url_with_query_parameters(
+        _query_builder,
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -122,12 +127,17 @@ module Square
     # desired `PaymentRefund`.
     # @return [GetPaymentRefundResponse Hash] response from the API call
     def get_payment_refund(refund_id:)
+      # Prepare parameters.
+      _parameters = {
+        'refund_id' => { 'value' => refund_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/refunds/{refund_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'refund_id' => { 'value' => refund_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/subscriptions_api.rb
+++ b/lib/square/api/subscriptions_api.rb
@@ -100,12 +100,17 @@ module Square
     # subscription to retrieve.
     # @return [RetrieveSubscriptionResponse Hash] response from the API call
     def retrieve_subscription(subscription_id:)
+      # Prepare parameters.
+      _parameters = {
+        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/subscriptions/{subscription_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -140,12 +145,17 @@ module Square
     # @return [UpdateSubscriptionResponse Hash] response from the API call
     def update_subscription(subscription_id:,
                             body:)
+      # Prepare parameters.
+      _parameters = {
+        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/subscriptions/{subscription_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -178,12 +188,17 @@ module Square
     # subscription to cancel.
     # @return [CancelSubscriptionResponse Hash] response from the API call
     def cancel_subscription(subscription_id:)
+      # Prepare parameters.
+      _parameters = {
+        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/subscriptions/{subscription_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -225,17 +240,25 @@ module Square
     def list_subscription_events(subscription_id:,
                                  cursor: nil,
                                  limit: nil)
+      # Prepare parameters.
+      _template_parameters = {
+        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'cursor' => cursor,
+        'limit' => limit
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/subscriptions/{subscription_id}/events'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'subscription_id' => { 'value' => subscription_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'cursor' => cursor,
-        'limit' => limit
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/terminal_api.rb
+++ b/lib/square/api/terminal_api.rb
@@ -80,12 +80,17 @@ module Square
     # `TerminalCheckout`
     # @return [GetTerminalCheckoutResponse Hash] response from the API call
     def get_terminal_checkout(checkout_id:)
+      # Prepare parameters.
+      _parameters = {
+        'checkout_id' => { 'value' => checkout_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/terminals/checkouts/{checkout_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'checkout_id' => { 'value' => checkout_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -116,12 +121,17 @@ module Square
     # `TerminalCheckout`
     # @return [CancelTerminalCheckoutResponse Hash] response from the API call
     def cancel_terminal_checkout(checkout_id:)
+      # Prepare parameters.
+      _parameters = {
+        'checkout_id' => { 'value' => checkout_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/terminals/checkouts/{checkout_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'checkout_id' => { 'value' => checkout_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -221,12 +231,17 @@ module Square
     # desired `TerminalRefund`
     # @return [GetTerminalRefundResponse Hash] response from the API call
     def get_terminal_refund(terminal_refund_id:)
+      # Prepare parameters.
+      _parameters = {
+        'terminal_refund_id' => { 'value' => terminal_refund_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/terminals/refunds/{terminal_refund_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'terminal_refund_id' => { 'value' => terminal_refund_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -257,12 +272,17 @@ module Square
     # desired `TerminalRefund`
     # @return [CancelTerminalRefundResponse Hash] response from the API call
     def cancel_terminal_refund(terminal_refund_id:)
+      # Prepare parameters.
+      _parameters = {
+        'terminal_refund_id' => { 'value' => terminal_refund_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/terminals/refunds/{terminal_refund_id}/cancel'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'terminal_refund_id' => { 'value' => terminal_refund_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/api/transactions_api.rb
+++ b/lib/square/api/transactions_api.rb
@@ -37,19 +37,27 @@ module Square
                      sort_order: nil,
                      cursor: nil)
       warn 'Endpoint list_refunds in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _template_parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'begin_time' => begin_time,
+        'end_time' => end_time,
+        'sort_order' => sort_order,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/refunds'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'begin_time' => begin_time,
-        'end_time' => end_time,
-        'sort_order' => sort_order,
-        'cursor' => cursor
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -103,19 +111,27 @@ module Square
                           sort_order: nil,
                           cursor: nil)
       warn 'Endpoint list_transactions in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _template_parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+      _query_parameters = {
+        'begin_time' => begin_time,
+        'end_time' => end_time,
+        'sort_order' => sort_order,
+        'cursor' => cursor
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _template_parameters
       )
       _query_builder = APIHelper.append_url_with_query_parameters(
         _query_builder,
-        'begin_time' => begin_time,
-        'end_time' => end_time,
-        'sort_order' => sort_order,
-        'cursor' => cursor
+        _query_parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -168,12 +184,17 @@ module Square
     def charge(location_id:,
                body:)
       warn 'Endpoint charge in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -209,13 +230,18 @@ module Square
     def retrieve_transaction(location_id:,
                              transaction_id:)
       warn 'Endpoint retrieve_transaction in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true },
+        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions/{transaction_id}'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true },
-        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -253,13 +279,18 @@ module Square
     def capture_transaction(location_id:,
                             transaction_id:)
       warn 'Endpoint capture_transaction in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true },
+        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions/{transaction_id}/capture'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true },
-        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -304,13 +335,18 @@ module Square
                       transaction_id:,
                       body:)
       warn 'Endpoint create_refund in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true },
+        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions/{transaction_id}/refund'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true },
-        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 
@@ -349,13 +385,18 @@ module Square
     def void_transaction(location_id:,
                          transaction_id:)
       warn 'Endpoint void_transaction in TransactionsApi is deprecated'
+      # Prepare parameters.
+      _parameters = {
+        'location_id' => { 'value' => location_id, 'encode' => true },
+        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+      }
+
       # Prepare query url.
       _query_builder = config.get_base_uri
       _query_builder << '/v2/locations/{location_id}/transactions/{transaction_id}/void'
       _query_builder = APIHelper.append_url_with_template_parameters(
         _query_builder,
-        'location_id' => { 'value' => location_id, 'encode' => true },
-        'transaction_id' => { 'value' => transaction_id, 'encode' => true }
+        _parameters
       )
       _query_url = APIHelper.clean_url _query_builder
 

--- a/lib/square/http/http_request.rb
+++ b/lib/square/http/http_request.rb
@@ -37,8 +37,9 @@ module Square
     # @param [String] The name of the query parameter.
     # @param [String] The value of the query parameter.
     def add_query_parameter(name, value)
+      parameters = { name => value }
       @query_url = APIHelper.append_url_with_query_parameters(@query_url,
-                                                              name => value)
+                                                              parameters)
       @query_url = APIHelper.clean_url(@query_url)
     end
   end


### PR DESCRIPTION
## Description
Refactors positional/keyword arguments when calling:
- `append_url_with_query_parameters`
- `append_url_with_template_parameters`

to work with Ruby 3.0

More details can be found here: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/