### PR TITLE
adding automerge github action for generated prs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# configuration settings for labeler
+
+version: v1
+
+labels:
+  - label: "automerge"
+    sync: true
+    matcher:
+      title: "^Generated PR for Release:"
+
+  - label: "automerge-author"
+    sync: true
+    matcher:
+      author:
+        - square-sdk-deployer
+
+  - label: "automerge-branch"
+    sync: true
+    matcher:
+      branch: "^release"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,33 @@
+# This workflow will trigger an automerge
+# Checks PR title, author, and branch name.
+# If the properties match a generated SDK PR,
+# corresponding labels are applied with labeler
+# and triggers automerge.
+
+name: Automerge
+on:
+  pull_request:
+    branches: [ master, main ]
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge-labeler
+        uses: fuxingloh/multi-labeler@v1
+
+  automerge:
+    needs: labeler
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.14.2"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge,automerge-branch,automerge-author"


### PR DESCRIPTION
Adding github actions for automerging generated PRs.
Checks the PR's title, author, and branch against a regex.
Only runs when merging to master/main branch.

Work item:
[DEX-6970](https://jira.sqprod.co/browse/DEX-6970)