### PR TITLE
remove deprecated faraday-middleware

### DIFF
--- a/lib/square/http/faraday_client.rb
+++ b/lib/square/http/faraday_client.rb
@@ -1,5 +1,6 @@
 require 'faraday/http_cache'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
+require 'faraday/gzip'
 
 module Square
   # An implementation of HttpClient.
@@ -27,8 +28,8 @@ module Square
                           cache: false, verify: true)
       Faraday.new do |faraday|
         faraday.use Faraday::HttpCache, serializer: Marshal if cache
-        faraday.use FaradayMiddleware::FollowRedirects
-        faraday.use :gzip
+        faraday.use Faraday::FollowRedirects::Middleware
+        faraday.request :gzip
         faraday.request :multipart
         faraday.request :url_encoded
         faraday.ssl[:ca_file] = Certifi.where

--- a/square.gemspec
+++ b/square.gemspec
@@ -8,8 +8,9 @@ Gem::Specification.new do |s|
   s.homepage = 'https://squareup.com/developers'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.3')
-  s.add_dependency('faraday', '~> 1.0', '>= 1.0.1')
-  s.add_dependency('faraday_middleware', '~> 1.0')
+  s.add_dependency('faraday', '~> 1.0', '< 3.0')
+  s.add_dependency('faraday-follow_redirects', '~> 0.3')
+  s.add_dependency('faraday-gzip', '~> 0.1')
   s.add_dependency('certifi', '~> 2018.1', '>= 2018.01.18')
   s.add_dependency('faraday-http-cache', '~> 2.2')
   s.add_development_dependency('minitest', '~> 5.14', '>= 5.14.1')


### PR DESCRIPTION
[Faraday::Middleware has been deprecated since 2020](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-middleware-deprecation). Using this also prevents migrating to Faraday 2.0 for all the users of this gem. This gem is the only gem that's preventing us from moving to Faraday 2.0 and migrating to Rails 7.0+.

This gem relies on two features of Faraday::Middleware. `following redirects` and `gzip`. 

Using two separate gems (per Faraday and Faraday::Middleware) to achieve the same functionality.

More information at: https://github.com/lostisland/awesome-faraday/#middleware