### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use this library to integrate Square payments into your app and grow your busine
 
 Use of the Square Ruby SDK requires:
 
-* Ruby 2.6 through 3.1
+* Ruby 2.7 through 3.1
 
 ## Installation
 


### PR DESCRIPTION
Ruby 2.6 is EOL, so bumping min requirement to 2.7