### PR TITLE
Override the Faraday Client to prevent the body on DELETE

### DIFF
--- a/lib/square.rb
+++ b/lib/square.rb
@@ -16,6 +16,7 @@ require_relative 'square/utilities/date_time_helper'
 
 # Http
 require_relative 'square/http/api_response'
+require_relative 'square/http/faraday_client'
 require_relative 'square/http/http_call_back'
 require_relative 'square/http/http_method_enum'
 require_relative 'square/http/http_request'

--- a/lib/square/configuration.rb
+++ b/lib/square/configuration.rb
@@ -43,7 +43,7 @@ module Square
       @additional_headers = additional_headers.clone
 
       # The Http Client to use for making requests.
-      set_http_client CoreLibrary::FaradayClient.new(self)
+      set_http_client Square::FaradayClient.new(self)
 
       # User agent detail, to be appended with user-agent header.
       @user_agent_detail = get_user_agent(user_agent_detail)

--- a/lib/square/http/faraday_client.rb
+++ b/lib/square/http/faraday_client.rb
@@ -1,0 +1,20 @@
+module Square
+  class FaradayClient < CoreLibrary::FaradayClient
+    # Method overridden from HttpClient.
+    # @param [HttpRequest] http_request The HttpRequest to be executed.
+    def execute(http_request)
+      response = @connection.send(
+        http_request.http_method.downcase,
+        http_request.query_url
+      ) do |request|
+        request.headers = http_request.headers.map { |k, v| [k.to_s, v.to_s] }
+        request.options.context ||= {}
+        request.options.context.merge!(http_request.context)
+        unless (http_request.http_method == HttpMethod::GET || http_request.http_method == HttpMethod::DELETE) && http_request.parameters.empty?
+          request.body = http_request.parameters
+        end
+      end
+      convert_response(response, http_request)
+    end
+  end
+end


### PR DESCRIPTION
The default API client seems to like sending an empty object in the request body, which Square doesn't like. In a previous fix the parameters were exposed such that they could simply be set to `nil` - I'm unsure the best way to accomplish this, with the new APIMatic setup since I last encountered this issue. This simply prevents the empty object from being set on the body, and thus the body is truly empty for the server to handle as JSON.