### PR TITLE
Release 42.0.0.20250319

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -5,7 +5,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `square_version` | `String` | Square Connect API versions<br>*Default*: `'2025-02-20'` |
+| `square_version` | `String` | Square Connect API versions<br>*Default*: `'2025-03-19'` |
 | `custom_url` | `String` | Sets the base URL requests are made to. Defaults to `https://connect.squareup.com`<br>*Default*: `'https://connect.squareup.com'` |
 | `environment` | `string` | The API environment. <br> **Default: `production`** |
 | `connection` | `Faraday::Connection` | The Faraday connection object passed by the SDK user for making requests |
@@ -25,7 +25,7 @@ The API client can be initialized as follows:
 
 ```ruby
 client = Square::Client.new(
-  square_version: '2025-02-20',
+  square_version: '2025-03-19',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),
@@ -55,7 +55,7 @@ require 'square'
 include Square
 
 client = Square::Client.new(
-  square_version: '2025-02-20',
+  square_version: '2025-03-19',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),

--- a/lib/square/api/base_api.rb
+++ b/lib/square/api/base_api.rb
@@ -5,7 +5,7 @@ module Square
     attr_accessor :config, :http_call_back
 
     def self.user_agent
-      'Square-Ruby-SDK/41.1.0.20250220 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
+      'Square-Ruby-SDK/42.0.0.20250319 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
     end
 
     def self.user_agent_parameters

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -5,7 +5,7 @@ module Square
     attr_reader :config, :auth_managers
 
     def sdk_version
-      '41.1.0.20250220'
+      '42.0.0.20250319'
     end
 
     def square_version
@@ -274,7 +274,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-02-20',
+      bearer_auth_credentials: nil, square_version: '2025-03-19',
       user_agent_detail: '', additional_headers: {}, config: nil
     )
       @config = if config.nil?

--- a/lib/square/configuration.rb
+++ b/lib/square/configuration.rb
@@ -24,7 +24,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-02-20',
+      bearer_auth_credentials: nil, square_version: '2025-03-19',
       user_agent_detail: '', additional_headers: {}
     )
 

--- a/square.gemspec
+++ b/square.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'square.rb'
-  s.version = '41.1.0.20250220'
+  s.version = '42.0.0.20250319'
   s.summary = 'square'
   s.description = ''
   s.authors = ['Square Developer Platform']


### PR DESCRIPTION
This prepares the `42.0.0.20250319` release. No significant changes are made in this release, but the versions are updated to match the latest API.