### PR TITLE
Add publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on: [push]
+
+jobs:
+  publish:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - name: Test gem
+        run: bundle install && bundle exec rake test
+
+      - name: Build and Push Gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          gem build square.gemspec
+
+          gem push square-*.gem --host https://rubygems.org/


### PR DESCRIPTION
This configures the `.github/workflows/publish.yml` job so that we're prepared to publish the next Ruby SDK version in May.