### PR TITLE
Release 43.0.0.20250521

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -5,7 +5,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `square_version` | `String` | Square Connect API versions<br>*Default*: `'2025-04-16'` |
+| `square_version` | `String` | Square Connect API versions<br>*Default*: `'2025-05-21'` |
 | `custom_url` | `String` | Sets the base URL requests are made to. Defaults to `https://connect.squareup.com`<br>*Default*: `'https://connect.squareup.com'` |
 | `environment` | `string` | The API environment. <br> **Default: `production`** |
 | `connection` | `Faraday::Connection` | The Faraday connection object passed by the SDK user for making requests |
@@ -25,7 +25,7 @@ The API client can be initialized as follows:
 
 ```ruby
 client = Square::Client.new(
-  square_version: '2025-04-16',
+  square_version: '2025-05-21',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),
@@ -55,7 +55,7 @@ require 'square'
 include Square
 
 client = Square::Client.new(
-  square_version: '2025-04-16',
+  square_version: '2025-05-21',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),

--- a/lib/square/api/base_api.rb
+++ b/lib/square/api/base_api.rb
@@ -5,7 +5,7 @@ module Square
     attr_accessor :config, :http_call_back
 
     def self.user_agent
-      'Square-Ruby-SDK/42.1.0.20250416 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
+      'Square-Ruby-SDK/43.0.0.20250521 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
     end
 
     def self.user_agent_parameters

--- a/lib/square/api/labor_api.rb
+++ b/lib/square/api/labor_api.rb
@@ -204,7 +204,9 @@ module Square
     # the fields to POST for the request.  See the corresponding object
     # definition for field details.
     # @return [ApiResponse]  the complete http response with raw body and status code.
+    # @deprecated This endpoint is deprecated at Square API version 2025-05-21. Use create_timecard instead.
     def create_shift(body:)
+      warn 'Endpoint create_shift in LaborApi is deprecated'
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::POST,
                                      '/v2/labor/shifts',
@@ -238,7 +240,9 @@ module Square
     # the fields to POST for the request.  See the corresponding object
     # definition for field details.
     # @return [ApiResponse]  the complete http response with raw body and status code.
+    # @deprecated This endpoint is deprecated at Square API version 2025-05-21. Use search_timecards instead.
     def search_shifts(body:)
+      warn 'Endpoint search_shifts in LaborApi is deprecated'
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::POST,
                                      '/v2/labor/shifts/search',
@@ -259,7 +263,9 @@ module Square
     # @param [String] id Required parameter: The UUID for the `Shift` being
     # deleted.
     # @return [ApiResponse]  the complete http response with raw body and status code.
+    # @deprecated This endpoint is deprecated at Square API version 2025-05-21. Use delete_timecard instead.
     def delete_shift(id:)
+      warn 'Endpoint delete_shift in LaborApi is deprecated'
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::DELETE,
                                      '/v2/labor/shifts/{id}',
@@ -279,7 +285,9 @@ module Square
     # @param [String] id Required parameter: The UUID for the `Shift` being
     # retrieved.
     # @return [ApiResponse]  the complete http response with raw body and status code.
+    # @deprecated This endpoint is deprecated at Square API version 2025-05-21. Use retrieve_timecard instead.
     def get_shift(id:)
+      warn 'Endpoint get_shift in LaborApi is deprecated'
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::GET,
                                      '/v2/labor/shifts/{id}',
@@ -308,8 +316,10 @@ module Square
     # the fields to POST for the request.  See the corresponding object
     # definition for field details.
     # @return [ApiResponse]  the complete http response with raw body and status code.
+    # @deprecated This endpoint is deprecated at Square API version 2025-05-21. Use update_timecard instead.
     def update_shift(id:,
                      body:)
+      warn 'Endpoint update_shift in LaborApi is deprecated'
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::PUT,
                                      '/v2/labor/shifts/{id}',
@@ -411,6 +421,292 @@ module Square
       new_api_call_builder
         .request(new_request_builder(HttpMethodEnum::PUT,
                                      '/v2/labor/workweek-configs/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Creates a new `Timecard`.
+    # A `Timecard` represents a complete workday for a single team member.
+    # You must provide the following values in your request to this
+    # endpoint:
+    # - `location_id`
+    # - `team_member_id`
+    # - `start_at`
+    # An attempt to create a new `Timecard` can result in a `BAD_REQUEST` error when:
+    # - The `status` of the new `Timecard` is `OPEN` and the team member has another
+    # timecard with an `OPEN` status.
+    # - The `start_at` date is in the future.
+    # - The `start_at` or `end_at` date overlaps another timecard for the same team member.
+    # - The `Break` instances are set in the request and a break `start_at`
+    # is before the `Timecard.start_at`, a break `end_at` is after
+    # the `Timecard.end_at`, or both.
+    # @param [CreateTimecardRequest] body Required parameter: An object containing
+    # the fields to POST for the request.  See the corresponding object
+    # definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def create_timecard(body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/timecards',
+                                     'default')
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Returns a paginated list of `Timecard` records for a business.
+    # The list to be returned can be filtered by:
+    # - Location IDs
+    # - Team member IDs
+    # - Timecard status (`OPEN` or `CLOSED`)
+    # - Timecard start
+    # - Timecard end
+    # - Workday details
+    # The list can be sorted by:
+    # - `START_AT`
+    # - `END_AT`
+    # - `CREATED_AT`
+    # - `UPDATED_AT`
+    # @param [SearchTimecardsRequest] body Required parameter: An object
+    # containing the fields to POST for the request.  See the corresponding
+    # object definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def search_timecards(body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/timecards/search',
+                                     'default')
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Deletes a `Timecard`.
+    # @param [String] id Required parameter: The UUID for the `Timecard` being
+    # deleted.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def delete_timecard(id:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::DELETE,
+                                     '/v2/labor/timecards/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Returns a single `Timecard` specified by `id`.
+    # @param [String] id Required parameter: The UUID for the `Timecard` being
+    # retrieved.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def retrieve_timecard(id:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::GET,
+                                     '/v2/labor/timecards/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Updates an existing `Timecard`.
+    # When adding a `Break` to a `Timecard`, any earlier `Break` instances in the
+    # `Timecard` have the `end_at` property set to a valid RFC-3339 datetime string.
+    # When closing a `Timecard`, all `Break` instances in the `Timecard` must be
+    # complete with `end_at` set on each `Break`.
+    # @param [String] id Required parameter: The ID of the `Timecard` to update.
+    # @param [UpdateTimecardRequest] body Required parameter: An object containing
+    # the fields to POST for the request. See the corresponding object
+    # definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def update_timecard(id:, body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::PUT,
+                                     '/v2/labor/timecards/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Creates a scheduled shift by providing draft shift details such as job ID,
+    # team member assignment, and start and end times.
+    # The following `draft_shift_details` fields are required:
+    # - `location_id`
+    # - `job_id`
+    # - `start_at`
+    # - `end_at`
+    # @param [CreateScheduledShiftRequest] body Required parameter: An object
+    # containing the fields to POST for the request. See the corresponding object
+    # definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def create_scheduled_shift(body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/scheduled-shifts',
+                                     'default')
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Publishes 1 - 100 scheduled shifts. This endpoint takes a map of individual publish
+    # requests and returns a map of responses. When a scheduled shift is published, Square keeps
+    # the `draft_shift_details` field as is and copies it to the `published_shift_details` field.
+    # The minimum `start_at` and maximum `end_at` timestamps of all shifts in a
+    # `BulkPublishScheduledShifts` request must fall within a two-week period.
+    # @param [BulkPublishScheduledShiftsRequest] body Required parameter: An object
+    # containing the fields to POST for the request. See the corresponding object
+    # definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def bulk_publish_scheduled_shifts(body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/scheduled-shifts/bulk-publish',
+                                     'default')
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Returns a paginated list of scheduled shifts, with optional filter and sort settings.
+    # By default, results are sorted by `start_at` in ascending order.
+    # @param [SearchScheduledShiftsRequest] body Required parameter: An object
+    # containing the fields to POST for the request. See the corresponding object
+    # definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def search_scheduled_shifts(body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/scheduled-shifts/search',
+                                     'default')
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Retrieves a scheduled shift by ID.
+    # @param [String] id Required parameter: The ID of the scheduled shift to retrieve.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def retrieve_scheduled_shift(id:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::GET,
+                                     '/v2/labor/scheduled-shifts/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Updates the draft shift details for a scheduled shift. This endpoint supports
+    # sparse updates, so only new, changed, or removed fields are required in the request.
+    # You must publish the shift to make updates public.
+    # @param [String] id Required parameter: The ID of the scheduled shift to update.
+    # @param [UpdateScheduledShiftRequest] body Required parameter: An object containing
+    # the fields to POST for the request. See the corresponding object definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def update_scheduled_shift(id:, body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::PUT,
+                                     '/v2/labor/scheduled-shifts/{id}',
+                                     'default')
+                   .template_param(new_parameter(id, key: 'id')
+                                    .should_encode(true))
+                   .header_param(new_parameter('application/json', key: 'Content-Type'))
+                   .body_param(new_parameter(body))
+                   .header_param(new_parameter('application/json', key: 'accept'))
+                   .body_serializer(proc do |param| param.to_json unless param.nil? end)
+                   .auth(Single.new('global')))
+        .response(new_response_handler
+                    .deserializer(APIHelper.method(:json_deserialize))
+                    .is_api_response(true)
+                    .convertor(ApiResponse.method(:create)))
+        .execute
+    end
+
+    # Publishes a scheduled shift. When a scheduled shift is published, Square keeps the
+    # `draft_shift_details` field as is and copies it to the `published_shift_details` field.
+    # @param [String] id Required parameter: The ID of the scheduled shift to publish.
+    # @param [PublishScheduledShiftRequest] body Required parameter: An object containing
+    # the fields to POST for the request. See the corresponding object definition for field details.
+    # @return [ApiResponse]  the complete http response with raw body and status code.
+    def publish_scheduled_shift(id:, body:)
+      new_api_call_builder
+        .request(new_request_builder(HttpMethodEnum::POST,
+                                     '/v2/labor/scheduled-shifts/{id}/publish',
                                      'default')
                    .template_param(new_parameter(id, key: 'id')
                                     .should_encode(true))

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -5,7 +5,7 @@ module Square
     attr_reader :config, :auth_managers
 
     def sdk_version
-      '42.1.0.20250416'
+      '43.0.0.20250521'
     end
 
     def square_version
@@ -274,7 +274,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-04-16',
+      bearer_auth_credentials: nil, square_version: '2025-05-21',
       user_agent_detail: '', additional_headers: {}, config: nil
     )
       @config = if config.nil?

--- a/lib/square/configuration.rb
+++ b/lib/square/configuration.rb
@@ -24,7 +24,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-04-16',
+      bearer_auth_credentials: nil, square_version: '2025-05-21',
       user_agent_detail: '', additional_headers: {}
     )
 

--- a/square.gemspec
+++ b/square.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'square.rb'
-  s.version = '42.1.0.20250416'
+  s.version = '43.0.0.20250521'
   s.summary = 'square'
   s.description = ''
   s.authors = ['Square Developer Platform']

--- a/test/api/test_labor_api.rb
+++ b/test/api/test_labor_api.rb
@@ -1,5 +1,3 @@
-
-
 require_relative 'api_test_base'
 
 class LaborApiTests < ApiTestBase
@@ -68,4 +66,17 @@ class LaborApiTests < ApiTestBase
     assert(ComparisonHelper.match_headers(expected_headers, @response_catcher.response.headers))
   end
 
+  def test_search_timecards()
+    # Perform the API call through the SDK function
+    result = @controller.search_timecards(body: {limit: 100})
+
+    # Test response code
+    assert_equal(200, @response_catcher.response.status_code)
+
+    # Test headers
+    expected_headers = {}
+    expected_headers['content-type'] = 'application/json'
+
+    assert(ComparisonHelper.match_headers(expected_headers, @response_catcher.response.headers))
+  end
 end


### PR DESCRIPTION
This prepares the `43.0.0.20250521` release. This release includes several new endpoints for timecards, which replace shift endpoints.