### PR TITLE
chore: update square version to `2025-06-18`

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -25,7 +25,7 @@ The API client can be initialized as follows:
 
 ```ruby
 client = Square::Client.new(
-  square_version: '2025-05-21',
+  square_version: '2025-06-18',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),
@@ -55,7 +55,7 @@ require 'square'
 include Square
 
 client = Square::Client.new(
-  square_version: '2025-05-21',
+  square_version: '2025-06-18',
   bearer_auth_credentials: BearerAuthCredentials.new(
     access_token: 'AccessToken'
   ),

--- a/lib/square/api/base_api.rb
+++ b/lib/square/api/base_api.rb
@@ -5,7 +5,7 @@ module Square
     attr_accessor :config, :http_call_back
 
     def self.user_agent
-      'Square-Ruby-SDK/42.3.0.20250618 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
+      'Square-Ruby-SDK/43.0.0.20250618 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
     end
 
     def self.user_agent_parameters

--- a/lib/square/api/base_api.rb
+++ b/lib/square/api/base_api.rb
@@ -5,7 +5,7 @@ module Square
     attr_accessor :config, :http_call_back
 
     def self.user_agent
-      'Square-Ruby-SDK/42.2.0.20250521 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
+      'Square-Ruby-SDK/42.3.0.20250618 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
     end
 
     def self.user_agent_parameters

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -5,7 +5,7 @@ module Square
     attr_reader :config, :auth_managers
 
     def sdk_version
-      '42.3.0.20250618'
+      '43.0.0.20250618'
     end
 
     def square_version

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -274,7 +274,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-05-21',
+      bearer_auth_credentials: nil, square_version: '2025-06-18',
       user_agent_detail: '', additional_headers: {}, config: nil
     )
       @config = if config.nil?

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -5,7 +5,7 @@ module Square
     attr_reader :config, :auth_managers
 
     def sdk_version
-      '42.2.0.20250521'
+      '42.3.0.20250618'
     end
 
     def square_version

--- a/lib/square/configuration.rb
+++ b/lib/square/configuration.rb
@@ -24,7 +24,7 @@ module Square
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], http_callback: nil, environment: 'production',
       custom_url: 'https://connect.squareup.com', access_token: nil,
-      bearer_auth_credentials: nil, square_version: '2025-05-21',
+      bearer_auth_credentials: nil, square_version: '2025-06-18',
       user_agent_detail: '', additional_headers: {}
     )
 

--- a/square.gemspec
+++ b/square.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'square.rb'
-  s.version = '42.2.0.20250521'
+  s.version = '42.3.0.20250618'
   s.summary = 'square'
   s.description = ''
   s.authors = ['Square Developer Platform']

--- a/square.gemspec
+++ b/square.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'square.rb'
-  s.version = '42.3.0.20250618'
+  s.version = '43.0.0.20250618'
   s.summary = 'square'
   s.description = ''
   s.authors = ['Square Developer Platform']


### PR DESCRIPTION
This PR prepares for releasing `42.3.0.20250618` and bumping the API version to '2025-06-18'.