### PR TITLE
Switch gem-publish to RubyGems OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
   workflow_dispatch:
 
@@ -75,6 +75,9 @@ jobs:
   gem-publish:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch'
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -92,8 +95,9 @@ jobs:
         run: |
           bundle exec rake build
 
+      - name: Configure RubyGems credentials (OIDC trusted publishing)
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
       - name: Publish to RubyGems
         run: |
           gem push pkg/*.gem --host https://rubygems.org/
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
           bundle exec rake build
 
       - name: Configure RubyGems credentials (OIDC trusted publishing)
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
+        # rubygems/configure-rubygems-credentials@v1.0.0
+        uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44
 
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
## What

Switches the `gem-publish` job to **RubyGems OIDC trusted publishing** instead of a long-lived API key.

## Why

The `gem-publish` job currently fails at the push step:

```
Rubygem requires owners to enable MFA. You must enable MFA before pushing new version.
```

`square.gemspec` sets `rubygems_mfa_required = "true"`, which RubyGems enforces server-side. CI authenticates with only `GEM_HOST_API_KEY`, which doesn't satisfy the MFA requirement, so every tagged release fails to publish.

Failing run: https://github.com/square/square-ruby-sdk/actions/runs/26183986707/job/77034487771

## Change

In `.github/workflows/ci.yml`, the `gem-publish` job now:
- adds `permissions: { id-token: write, contents: read }`
- runs `rubygems/configure-rubygems-credentials@v1.0.0` to mint a short-lived OIDC token
- drops the `GEM_HOST_API_KEY` / `RUBYGEMS_API_KEY` secret from the push step

This keeps the MFA requirement intact (no security downgrade) and removes the long-lived API key. It mirrors what the current Fern Ruby generator (`fern-ruby-sdk` rc68+) emits natively; this repo's `.github/workflows` is `.fernignore`-protected, so this edit is durable and won't be overwritten on regeneration.

## Action required before this works (gem owner)

After merging, register this repo as a **Trusted Publisher** on RubyGems for the `square.rb` gem:

RubyGems → `square.rb` → **Settings → Trusted Publishers → Add a GitHub Actions publisher**:
- Repository: `square/square-ruby-sdk`
- Workflow filename: `ci.yml`

Once that's set, the next tagged release will publish via OIDC with no API key.
