### PR TITLE
Fix CI for July release: restore x86_64-linux platform in Gemfile.lock

### DIFF
--- a/.fern/metadata.json
+++ b/.fern/metadata.json
@@ -1,9 +1,10 @@
 {
-  "cliVersion": "3.98.5",
+  "cliVersion": "5.56.0",
   "generatorName": "fernapi/fern-ruby-sdk",
   "generatorVersion": "1.0.0-rc84",
   "generatorConfig": {
     "enableWireTests": true
   },
-  "sdkVersion": "45.2.0-rc.0"
+  "originGitCommit": "4b035f25928bb22328fb84412043abb52d24de61",
+  "sdkVersion": "46.0.0.20260715"
 }

--- a/.fern/replay.lock
+++ b/.fern/replay.lock
@@ -6,5 +6,11 @@ generations:
     timestamp: 2026-05-19T21:18:26.039Z
     cli_version: unknown
     generator_versions: {}
-current_generation: f631923c98d9161665156652789a58902009b805
+  - commit_sha: 73116ac88eb274f733272e287614d5f2961907b9
+    tree_hash: 66b13709a73a2a08f1444f201ace247b37b94d41
+    timestamp: 2026-07-13T21:33:48.371Z
+    cli_version: unknown
+    generator_versions:
+      fernapi/fern-ruby-sdk: 1.0.0-rc84
+current_generation: 73116ac88eb274f733272e287614d5f2961907b9
 patches: []

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux-musl
+  x86_64-linux
 
 DEPENDENCIES
   minitest (~> 5.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    square.rb (45.2.0.pre.rc.0)
+    square.rb (46.0.0.20260715)
 
 GEM
   remote: https://rubygems.org/
@@ -16,8 +16,8 @@ GEM
       rexml
     hashdiff (1.2.1)
     io-console (0.8.2)
-    json (2.19.9)
-    language_server-protocol (3.17.0.5)
+    json (2.21.1)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     method_source (1.1.0)
     minitest (5.27.0)
@@ -40,7 +40,7 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rubocop (1.88.0)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -51,7 +51,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-minitest (0.39.1)
@@ -69,7 +69,7 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   minitest (~> 5.16)

--- a/lib/square/client.rb
+++ b/lib/square/client.rb
@@ -10,7 +10,7 @@ module Square
       @raw_client = Square::Internal::Http::RawClient.new(
         base_url: base_url || Square::Environment::PRODUCTION,
         headers: {
-          "User-Agent" => "square.rb/45.2.0-rc.0",
+          "User-Agent" => "square.rb/46.0.0.20260715",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
         }

--- a/lib/square/types/loyalty_event.rb
+++ b/lib/square/types/loyalty_event.rb
@@ -7,7 +7,7 @@ module Square
     # Events](https://developer.squareup.com/docs/loyalty-api/loyalty-events).
     class LoyaltyEvent < Internal::Types::Model
       field :id, -> { String }, optional: true, nullable: false
-      field :type, -> { Square::Types::LoyaltyEventType }, optional: false, nullable: false
+      field :type, -> { Square::Types::LoyaltyEventType }, optional: true, nullable: false
       field :created_at, -> { String }, optional: true, nullable: false
       field :accumulate_points, -> { Square::Types::LoyaltyEventAccumulatePoints }, optional: true, nullable: false
       field :create_reward, -> { Square::Types::LoyaltyEventCreateReward }, optional: true, nullable: false
@@ -16,7 +16,7 @@ module Square
       field :adjust_points, -> { Square::Types::LoyaltyEventAdjustPoints }, optional: true, nullable: false
       field :loyalty_account_id, -> { String }, optional: true, nullable: false
       field :location_id, -> { String }, optional: true, nullable: false
-      field :source, -> { Square::Types::LoyaltyEventSource }, optional: false, nullable: false
+      field :source, -> { Square::Types::LoyaltyEventSource }, optional: true, nullable: false
       field :expire_points, -> { Square::Types::LoyaltyEventExpirePoints }, optional: true, nullable: false
       field :other_event, -> { Square::Types::LoyaltyEventOther }, optional: true, nullable: false
       field :accumulate_promotion_points, -> { Square::Types::LoyaltyEventAccumulatePromotionPoints }, optional: true, nullable: false

--- a/lib/square/version.rb
+++ b/lib/square/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Square
-  VERSION = "45.2.0-rc.0"
+  VERSION = "46.0.0.20260715"
 end


### PR DESCRIPTION
## Summary
- The July 2026 regeneration (fern-ruby-sdk 1.0.0-rc84) was produced in a musl container and rewrote `PLATFORMS` in `Gemfile.lock` from `x86_64-linux` to `x86_64-linux-musl`. The `test` matrix jobs on #226 run on ubuntu-latest and fail during `bundle install` with "Could not find gem 'nokogiri' with platform 'x86_64-linux-musl'".
- Reverts the platform entry to `x86_64-linux`. With this change the lockfile diff vs master is only the expected version bumps (square.rb 46.0.0.20260715, json, language_server-protocol, rubocop, rubocop-ast) — the same state that was green on master.

This PR targets the `fern-bot/2026-07-13_21-33-48_865` release branch so #226 goes green once merged.

Made with [Cursor](https://cursor.com)